### PR TITLE
the only fix needed for OS X support

### DIFF
--- a/linux/SSTAsm.cpp
+++ b/linux/SSTAsm.cpp
@@ -10,6 +10,9 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
+#ifdef __APPLE__
+#include <time.h>
+#endif
 #include "../diskimg/DiskImg.h"
 
 using namespace DiskImgLib;

--- a/linux/SSTAsm.cpp
+++ b/linux/SSTAsm.cpp
@@ -10,9 +10,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
-#ifdef __APPLE__
 #include <time.h>
-#endif
 #include "../diskimg/DiskImg.h"
 
 using namespace DiskImgLib;


### PR DESCRIPTION
Hi there,

Just came across ciderpress today.  I've been kickstarting my Apple II interests lately and was looking for exactly this tool.  I noticed that when I compile the linux tools on OS X there is only one small type definition missing (time_t).  

I found that by including time.h in one cpp file, everything builds just fine on OS X.  If this is of any use, great - if not, feel free to disregard!

Thanks for writing ciderpress!
Joe