### PR TITLE
Raw Filename Accessor in A2File, et al.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,7 @@ tags
 # VIM
 *~
 *.swp
+
+# Doxygen
+
+diskimg/doc/

--- a/diskimg/DOS33.cpp
+++ b/diskimg/DOS33.cpp
@@ -2877,7 +2877,7 @@ bail:
  * If a pointer to a size_t is passed in, it will be filled with the
  * raw filename length.
  */
-const char* A2FileDOS::GetRawFileName(size_t* size = NULL) const {
+const char* A2FileDOS::GetRawFileName(size_t* size) const {
     if (size) {
         *size = strlen(fRawFileName);
     }

--- a/diskimg/DOS33.cpp
+++ b/diskimg/DOS33.cpp
@@ -835,8 +835,8 @@ DIError DiskFSDOS33::ProcessCatalogSector(int catTrack, int catSect,
                 break;
             }
 
-            memcpy(pFile->fRawName, &pEntry[0x03], A2FileDOS::kMaxFileName);
-            pFile->fRawName[A2FileDOS::kMaxFileName] = '\0';
+            memcpy(pFile->fRawFileName, &pEntry[0x03], A2FileDOS::kMaxFileName);
+            pFile->fRawFileName[A2FileDOS::kMaxFileName] = '\0';
 
             memcpy(pFile->fFileName, &pEntry[0x03], A2FileDOS::kMaxFileName);
             pFile->fFileName[A2FileDOS::kMaxFileName] = '\0';
@@ -862,7 +862,6 @@ DIError DiskFSDOS33::ProcessCatalogSector(int catTrack, int catSect,
 
     return kDIErrNone;
 }
-
 
 /*
  * Perform consistency checks on the filesystem.
@@ -2870,6 +2869,19 @@ DIError A2FileDOS::ExtractTSPairs(const uint8_t* sctBuf, TrackSector* tsList,
 
 bail:
     return dierr;
+}
+
+/*
+ * Returns the raw filename.
+ *
+ * If a pointer to a size_t is passed in, it will be filled with the
+ * raw filename length.
+ */
+const char* A2FileDOS::GetRawFileName(size_t* size = NULL) const {
+    if (size) {
+        *size = strlen(fRawFileName);
+    }
+    return fRawFileName;
 }
 
 

--- a/diskimg/DOS33.cpp
+++ b/diskimg/DOS33.cpp
@@ -835,6 +835,9 @@ DIError DiskFSDOS33::ProcessCatalogSector(int catTrack, int catSect,
                 break;
             }
 
+            memcpy(pFile->fRawName, &pEntry[0x03], A2FileDOS::kMaxFileName);
+            pFile->fRawName[A2FileDOS::kMaxFileName] = '\0';
+
             memcpy(pFile->fFileName, &pEntry[0x03], A2FileDOS::kMaxFileName);
             pFile->fFileName[A2FileDOS::kMaxFileName] = '\0';
             pFile->FixFilename();

--- a/diskimg/DiskImg.cpp
+++ b/diskimg/DiskImg.cpp
@@ -292,6 +292,12 @@ void DiskImg::SetCustomNibbleDescr(const NibbleDescr* pDescr)
     }
 }
 
+const char* DiskImg::GetRawFileName(size_t* size) const { // get unmodified file name
+    if (size) {
+        *size = strlen(GetFileName());
+    }
+    return GetFileName();
+}
 
 /*
  * Open a volume or a file on disk.

--- a/diskimg/DiskImg.cpp
+++ b/diskimg/DiskImg.cpp
@@ -292,7 +292,7 @@ void DiskImg::SetCustomNibbleDescr(const NibbleDescr* pDescr)
     }
 }
 
-const char* DiskImg::GetRawFileName(size_t* size) const { // get unmodified file name
+const char* A2File::GetRawFileName(size_t* size) const { // get unmodified file name
     if (size) {
         *size = strlen(GetFileName());
     }

--- a/diskimg/DiskImg.h
+++ b/diskimg/DiskImg.h
@@ -1474,6 +1474,9 @@ public:
      * means that embedded nulls in HFS filenames (which are discouraged but
      * allowed) will be lost.
      *
+     * The original unmodified filename is availale through GetRawFileName,
+     * though HFS still suffers from embedded nulls.
+     * 
      * We do guarantee that the contents of subdirectories are grouped
      * together.  This makes it much easier to construct a hierarchy out of
      * the linear list.  This becomes important when dynamically adding
@@ -1481,6 +1484,9 @@ public:
      */
     virtual const char* GetFileName(void) const = 0;    // name of this file
     virtual const char* GetPathName(void) const = 0;    // full path
+    virtual const char* GetRawFileName(void) const {    // get unmodified file name
+        return GetFileName();
+    }
     virtual char GetFssep(void) const = 0;              // '\0' if none
     virtual uint32_t GetFileType(void) const = 0;
     virtual uint32_t GetAuxType(void) const = 0;

--- a/diskimg/DiskImg.h
+++ b/diskimg/DiskImg.h
@@ -1475,7 +1475,9 @@ public:
      * allowed) will be lost.
      *
      * The original unmodified filename is availale through GetRawFileName,
-     * though HFS still suffers from embedded nulls.
+     * which can be optionally passed a size_t pointer to get the size
+     * of the raw file name, which is helpful for getting a HFS filename with
+     * embedded nulls.
      * 
      * We do guarantee that the contents of subdirectories are grouped
      * together.  This makes it much easier to construct a hierarchy out of
@@ -1484,9 +1486,7 @@ public:
      */
     virtual const char* GetFileName(void) const = 0;    // name of this file
     virtual const char* GetPathName(void) const = 0;    // full path
-    virtual const char* GetRawFileName(void) const {    // get unmodified file name
-        return GetFileName();
-    }
+    virtual const char* GetRawFileName(size_t* size = NULL) const; // get unmodified file name
     virtual char GetFssep(void) const = 0;              // '\0' if none
     virtual uint32_t GetFileType(void) const = 0;
     virtual uint32_t GetAuxType(void) const = 0;

--- a/diskimg/DiskImgDetail.h
+++ b/diskimg/DiskImgDetail.h
@@ -1444,7 +1444,7 @@ public:
      */
     virtual const char* GetFileName(void) const override { return fFileName; }
     virtual const char* GetPathName(void) const override { return fFileName; }
-    virtual const char* GetRawFileName(void) const override { return fRawFileName; }
+    virtual const char* GetRawFileName(size_t* size = NULL) const override;
     virtual char GetFssep(void) const override { return '\0'; }
     virtual uint32_t GetFileType(void) const override;
     virtual uint32_t GetAuxType(void) const override { return fAuxType; }
@@ -2495,7 +2495,7 @@ public:
      */
     virtual const char* GetFileName(void) const override { return fFileName; }
     virtual const char* GetPathName(void) const override { return fFileName; }
-    virtual const char* GetRawFileName(void) const override { return fRawName; }
+    virtual const char* GetRawFileName(size_t* size = NULL) const override;
     virtual char GetFssep(void) const override { return '\0'; }
     virtual uint32_t GetFileType(void) const override;
     virtual uint32_t GetAuxType(void) const override { return fLoadAddr; }
@@ -2521,7 +2521,7 @@ public:
 
     /* fields pulled out of directory block */
     char            fFileName[kMaxFileName+1];
-    char            fRawName[kMaxFileName + 1];
+    char            fRawFileName[kMaxFileName + 1];
     FileType        fFileType;
     uint16_t        fNumSectors;
     uint16_t        fLoadAddr;

--- a/diskimg/DiskImgDetail.h
+++ b/diskimg/DiskImgDetail.h
@@ -1444,6 +1444,7 @@ public:
      */
     virtual const char* GetFileName(void) const override { return fFileName; }
     virtual const char* GetPathName(void) const override { return fFileName; }
+    virtual const char* GetRawFileName(void) const override { return fRawFileName; }
     virtual char GetFssep(void) const override { return '\0'; }
     virtual uint32_t GetFileType(void) const override;
     virtual uint32_t GetAuxType(void) const override { return fAuxType; }
@@ -1482,6 +1483,7 @@ private:
     short       fTSListSector;
     uint16_t    fLengthInSectors;
     bool        fLocked;
+    char        fRawFileName[kMaxFileName + 1]; // "raw" version
     char        fFileName[kMaxFileName+1];  // "fixed" version
     FileType    fFileType;
 
@@ -2493,6 +2495,7 @@ public:
      */
     virtual const char* GetFileName(void) const override { return fFileName; }
     virtual const char* GetPathName(void) const override { return fFileName; }
+    virtual const char* GetRawFileName(void) const override { return fRawName; }
     virtual char GetFssep(void) const override { return '\0'; }
     virtual uint32_t GetFileType(void) const override;
     virtual uint32_t GetAuxType(void) const override { return fLoadAddr; }
@@ -2518,6 +2521,7 @@ public:
 
     /* fields pulled out of directory block */
     char            fFileName[kMaxFileName+1];
+    char            fRawName[kMaxFileName + 1];
     FileType        fFileType;
     uint16_t        fNumSectors;
     uint16_t        fLoadAddr;

--- a/diskimg/ImageWrapper.cpp
+++ b/diskimg/ImageWrapper.cpp
@@ -1145,7 +1145,7 @@ DIError WrapperDiskCopy42::WriteHeader(GenericFD* pGFD, const DC42Header* pHeade
      * magic string.  To be safe, we only increment it if it starts with '-'.
      * (Need access to a Macintosh to test this.)
      */
-    hdrBuf[0] = (uint8_t) (strlen(pHeader->diskName) % 0xff);
+    hdrBuf[0] = (uint8_t) (strlen(pHeader->diskName) & 0xff);
     if (pHeader->diskName[0] == '-' && hdrBuf[0] < (kDC42NameLen-1))
         hdrBuf[0]++;
     memcpy(&hdrBuf[1], pHeader->diskName, hdrBuf[0]);

--- a/diskimg/ImageWrapper.cpp
+++ b/diskimg/ImageWrapper.cpp
@@ -1145,7 +1145,7 @@ DIError WrapperDiskCopy42::WriteHeader(GenericFD* pGFD, const DC42Header* pHeade
      * magic string.  To be safe, we only increment it if it starts with '-'.
      * (Need access to a Macintosh to test this.)
      */
-    hdrBuf[0] = strlen(pHeader->diskName);
+    hdrBuf[0] = (uint8_t) (strlen(pHeader->diskName) % 0xff);
     if (pHeader->diskName[0] == '-' && hdrBuf[0] < (kDC42NameLen-1))
         hdrBuf[0]++;
     memcpy(&hdrBuf[1], pHeader->diskName, hdrBuf[0]);

--- a/diskimg/RDOS.cpp
+++ b/diskimg/RDOS.cpp
@@ -344,6 +344,9 @@ DIError DiskFSRDOS::ReadCatalog(void)
 
         pFile = new A2FileRDOS(this);
 
+        memcpy(pFile->fRawName, dirPtr, A2FileRDOS::kMaxFileName);
+        pFile->fRawName[A2FileRDOS::kMaxFileName] = '\0';
+
         memcpy(pFile->fFileName, dirPtr, A2FileRDOS::kMaxFileName);
         pFile->fFileName[A2FileRDOS::kMaxFileName] = '\0';
         pFile->FixFilename();

--- a/diskimg/RDOS.cpp
+++ b/diskimg/RDOS.cpp
@@ -344,8 +344,8 @@ DIError DiskFSRDOS::ReadCatalog(void)
 
         pFile = new A2FileRDOS(this);
 
-        memcpy(pFile->fRawName, dirPtr, A2FileRDOS::kMaxFileName);
-        pFile->fRawName[A2FileRDOS::kMaxFileName] = '\0';
+        memcpy(pFile->fRawFileName, dirPtr, A2FileRDOS::kMaxFileName);
+        pFile->fRawFileName[A2FileRDOS::kMaxFileName] = '\0';
 
         memcpy(pFile->fFileName, dirPtr, A2FileRDOS::kMaxFileName);
         pFile->fFileName[A2FileRDOS::kMaxFileName] = '\0';
@@ -522,6 +522,19 @@ DIError A2FileRDOS::Open(A2FileDescr** ppOpenFile, bool readOnly,
     pOpenFile = NULL;
 
     return kDIErrNone;
+}
+
+/*
+ * Returns the raw filename.
+ *
+ * If a pointer to a size_t is passed in, it will be filled with the
+ * raw filename length.
+ */
+const char* A2FileRDOS::GetRawFileName(size_t* size = NULL) const {
+    if (size) {
+        *size = strlen(fRawFileName);
+    }
+    return fRawFileName;
 }
 
 

--- a/diskimg/RDOS.cpp
+++ b/diskimg/RDOS.cpp
@@ -530,7 +530,7 @@ DIError A2FileRDOS::Open(A2FileDescr** ppOpenFile, bool readOnly,
  * If a pointer to a size_t is passed in, it will be filled with the
  * raw filename length.
  */
-const char* A2FileRDOS::GetRawFileName(size_t* size = NULL) const {
+const char* A2FileRDOS::GetRawFileName(size_t* size) const {
     if (size) {
         *size = strlen(fRawFileName);
     }


### PR DESCRIPTION
This adds an accessor, GetRawFileName(size_t *optional_size_var = NULL), to A2File and its descendants.  

It can take an optional variable to return the size of the raw file name.  

In the A2File base class it just returns a redirected call to GetFileName().  However, in RDOS and DOS33, it returns the "unfixed" filenames.  

Although the size variable gives a good hook to implement it, I have not implemented support for HFS, as I don't have a good image to test it with and I am fairly unfamiliar with the file system.  I assume that it shouldn't be difficult to capture the length from the pascal string that holds the file name and coax it into the size_var, if it exists.  (Assuming that the original length's worth of data in the pascal string actually is copied into the fFileName variable -- I didn't check.)
